### PR TITLE
Add the Plausible Analytics script

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,9 @@
 
       gtag('config', 'UA-45185336-1');
     </script>
+    
+    <!-- Plausible Analytics script -->
+    <script defer data-domain="simpeg.xyz" src="https://plausible.io/js/plausible.js"></script>
 </head>
 <body>
     <ul class="nav">


### PR DESCRIPTION
The script will gather anonymous visitor data along side the Google Analytics script. Plausible is GDPR compliant and doesn't do any cross-site tracking.

This is trial that Software Underground are funding (Plausible is paid). If you're interested, feel free to merge and I can add people as admins on Plausible. For a glimpse at their dashboard, you can see the public fatiando.org data: https://plausible.io/fatiando.org