### PR TITLE
Fix link to contributing guidelines

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
                 <li><i class="fas fa-bookmark fa-lg"></i> Cite the <a href="https://scholar.google.ca/scholar?oi=bibs&hl=en&cites=880081470240461169&as_sdt=5">papers and project</a> (see below)</li>
                 <li><i class="fas fa-bug fa-lg"></i><a href="https://github.com/simpeg/simpeg/issues">Submitting bugs</a> when things don't work</li>
                 <li><i class="fas fa-book fa-lg"></i>Fix typos and add examples to the <a href="https://docs.simpeg.xyz">documentation</a></li>
-                <li><i class="fa fa-terminal"></i><a href="https://github.com/simpeg/simpeg/blob/master/CONTRIBUTING.rst">Contribute some code</a></li>
+                <li><i class="fa fa-terminal"></i><a href="https://github.com/simpeg/simpeg/blob/main/CONTRIBUTING.md">Contribute some code</a></li>
             </ul>
         </p>
         <h4>SimPEG Framework Paper</h4>


### PR DESCRIPTION
Update the link to the Contributing Guidelines located in the `CONTRIBUTING.md` file in the https://github.com/simpeg/simpeg repo.