### PR TITLE
Fix link to Install SimPEG

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 
       gtag('config', 'UA-45185336-1');
     </script>
-    
+
     <!-- Plausible Analytics script -->
     <script defer data-domain="simpeg.xyz" src="https://plausible.io/js/plausible.js"></script>
 </head>
@@ -141,7 +141,7 @@
         <div class="columns">
             <div class="column">
                 <ul class="icons">
-                    <li><i class="fab fa-python fa-lg"></i> <a href="https://docs.simpeg.xyz/content/basic/installing.html">Install SimPEG</a></li>
+                    <li><i class="fab fa-python fa-lg"></i> <a href="https://docs.simpeg.xyz/content/getting_started/installing.html">Install SimPEG</a></li>
                     <li><i class="fas fa-book fa-lg"></i> <a href="https://docs.simpeg.xyz">Read the documentation</a></li>
                     <li><i class="fab fa-discourse fa-lg"></i> <a href="https://simpeg.discourse.group">Join the community forum</a></li>
                     <li><i class="fab fa-slack fa-lg"></i> <a href="http://slack.simpeg.xyz">Chat to scientists and developers</a></li>


### PR DESCRIPTION
Fix the broken link to installation instructions for SimPEG.

Fixes https://github.com/simpeg/simpeg/issues/1281