### PR TITLE
Add links to User Tutorials

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,6 +66,11 @@
         </a>
       </li>
       <li>
+        <a href="https://simpeg.xyz/user-tutorials" title="User Tutorials">
+          <i class="fas fa-book-reader fa-lg"></i>
+        </a>
+      </li>
+      <li>
         <a
           href="https://cdn.forms-content.sg-form.com/ed4ab287-df4b-11eb-88f6-421855200eee"
           title="Sign up for the Newsletter"
@@ -168,12 +173,48 @@
         <div class="columns">
             <div class="column">
                 <ul class="icons">
-                    <li><i class="fab fa-python fa-lg"></i> <a href="https://docs.simpeg.xyz/content/getting_started/installing.html">Install SimPEG</a></li>
-                    <li><i class="fas fa-book fa-lg"></i> <a href="https://docs.simpeg.xyz">Read the documentation</a></li>
-                    <li><i class="fab fa-discourse fa-lg"></i> <a href="https://simpeg.discourse.group">Join the community forum</a></li>
-                    <li><i class="fab fa-slack fa-lg"></i> <a href="http://slack.simpeg.xyz">Chat to scientists and developers</a></li>
-                    <li><i class="fas fa-copy fa-lg"></i> <a href="https://doi.org/10.1016/j.cageo.2015.09.015">Read the SimPEG paper</a></li>
-                    <li><i class="fab fa-github fa-lg"></i> <a href="https://github.com/simpeg/simpeg">Read some code</a></li>
+                    <li>
+                      <i class="fab fa-python fa-lg"></i>
+                      <a href="https://docs.simpeg.xyz/content/getting_started/installing.html">
+                        Install SimPEG
+                      </a>
+                    </li>
+                    <li>
+                      <i class="fas fa-book fa-lg"></i>
+                      <a href="https://docs.simpeg.xyz">
+                        Read the documentation
+                      </a>
+                    </li>
+                    <li>
+                      <i class="fas fa-book-reader fa-lg"></i>
+                      <a href="https://simpeg.xyz/user-tutorials" title="User Tutorials">
+                        Learn from the User Tutorials
+                      </a>
+                    </li>
+                    <li>
+                      <i class="fab fa-discourse fa-lg"></i>
+                      <a href="https://simpeg.discourse.group">
+                        Join the community forum
+                      </a>
+                    </li>
+                    <li>
+                      <i class="fab fa-slack fa-lg"></i>
+                      <a href="http://slack.simpeg.xyz">
+                        Chat to scientists and developers
+                      </a>
+                    </li>
+                    <li>
+                      <i class="fas fa-copy fa-lg"></i>
+                      <a href="https://doi.org/10.1016/j.cageo.2015.09.015">
+                        Read the SimPEG paper
+                      </a>
+                    </li>
+                    <li>
+                      <i class="fab fa-github fa-lg"></i>
+                      <a href="https://github.com/simpeg/simpeg">
+                        Read some code
+                      </a>
+                    </li>
                 </ul>
             </div>
             <div class="column">


### PR DESCRIPTION
Add link to the new User Tutorials in the navbar and in the Get Started section.

Fixes #22 