### PR TITLE
Replace Slack links to Mattermost

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,11 @@
         </a>
       </li>
       <li>
-        <a href="http://slack.simpeg.xyz" title="Slack">
-          <i class="fab fa-slack fa-lg"></i>
+        <a
+          href="https://mattermost.softwareunderground.org/simpeg"
+          title="Mattermost"
+        >
+          <i class="fas fa-comment fa-lg"></i>
         </a>
       </li>
       <li>
@@ -164,11 +167,13 @@
 
         <h2 id="start">&#x1F680; Get Started &#x1F680;</h2>
         <p>
-            The easiest way to install SimPEG is from <a href="https://pypi.python.org/pypi/simpeg">PyPI</a>,
-            using <a href="https://pypi.python.org/pypi/pip">pip</a>.
-            If you get stuck or have no idea what a <i>pip</i> is, jump on <a href="http://slack.simpeg.xyz">Slack</a> or
-            <a href="https://simpeg.discourse.group">Discourse</a> to
-            ask the community a question!!
+          The easiest way to install SimPEG is from
+          <a href="https://pypi.python.org/pypi/simpeg">PyPI</a>, using
+          <a href="https://pypi.python.org/pypi/pip">pip</a>. If you get stuck or have
+          no idea what a <i>pip</i> is, jump on
+          <a href="https://mattermost.softwareunderground.org/simpeg">Mattermost</a> or
+          <a href="https://simpeg.discourse.group">Discourse</a> to ask the community a
+          question!!
         </p>
         <div class="columns">
             <div class="column">
@@ -198,8 +203,8 @@
                       </a>
                     </li>
                     <li>
-                      <i class="fab fa-slack fa-lg"></i>
-                      <a href="http://slack.simpeg.xyz">
+                      <i class="fas fa-comment fa-lg"></i>
+                      <a href="https://mattermost.softwareunderground.org/simpeg">
                         Chat to scientists and developers
                       </a>
                     </li>
@@ -225,13 +230,34 @@
         <h2 id="contact">&#x1F4E2; Contacting Us &#x1F4E2;</h2>
         Please don't hesitate to reach out and ask a question! We love to hear about how people are using or want to use SimPEG!
         <p>
-            <ul class="icons">
-                <li><i class="fas fa-envelope fa-lg"></i><a href="https://cdn.forms-content.sg-form.com/ed4ab287-df4b-11eb-88f6-421855200eee">Sign up for the newsletter</a></li>
-                <li><i class="fab fa-discourse fa-lg"></i>Join the community forum on <a href="https://simpeg.discourse.group">Discourse</a></li>
-                <li><i class="fab fa-slack fa-lg"></i>Send us a message on <a href="http://slack.simpeg.xyz">Slack</a></li>
-                <li><i class="fab fa-github fa-lg"></i>Contact us on <a href="https://github.com/simpeg">GitHub</a> by creating a <a href="https://github.com/simpeg/simpeg/issues/new">new issue</a></li>
-                <li><i class="fab fa-youtube fa-lg"></i>Join a weekly meeting organized on <a href="http://slack.simpeg.xyz">Slack</a> or see previous meetings on <a href="https://www.youtube.com/c/geoscixyz">YouTube</a></li>
-            </ul>
+          <ul class="icons">
+            <li>
+              <i class="fas fa-envelope fa-lg"></i
+              ><a
+                href="https://cdn.forms-content.sg-form.com/ed4ab287-df4b-11eb-88f6-421855200eee"
+                >Sign up for the newsletter</a
+              >
+            </li>
+            <li>
+              <i class="fab fa-discourse fa-lg"></i>Join the community forum on
+              <a href="https://simpeg.discourse.group">Discourse</a>
+            </li>
+            <li>
+              <i class="fas fa-comment fa-lg"></i>Send us a message on
+              <a href="https://mattermost.softwareunderground.org/simpeg">Mattermost</a>
+            </li>
+            <li>
+              <i class="fab fa-github fa-lg"></i>Contact us on
+              <a href="https://github.com/simpeg">GitHub</a> by creating a
+              <a href="https://github.com/simpeg/simpeg/issues/new">new issue</a>
+            </li>
+            <li>
+              <i class="fab fa-youtube fa-lg"></i>Join a weekly meeting organized on
+              <a href="https://mattermost.softwareunderground.org/simpeg">Mattermost</a>
+              or see previous meetings on
+              <a href="https://www.youtube.com/c/geoscixyz">YouTube</a>
+            </li>
+          </ul>
         </p>
 
         <h2 id="contribute">&#x1F64C; Contribute &#x1F64C;</h2>


### PR DESCRIPTION
Update links to Slack in `index.html`: make them point to Mattermost. Use the `fab fa-comments` FontAwesome icon for Mattermost links.
