### PR TITLE
Update link to getting started guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
                 <ul class="icons">
                     <li>
                       <i class="fab fa-python fa-lg"></i>
-                      <a href="https://docs.simpeg.xyz/content/getting_started/installing.html">
+                      <a href="https://docs.simpeg.xyz/latest/content/getting_started/installing.html">
                         Install SimPEG
                       </a>
                     </li>


### PR DESCRIPTION
Use the new link to the getting started guide under `docs.simpeg.xyz/latest`. The previous link redirects to the new one, so this is not a critical change.
